### PR TITLE
Fix organization retrieval on server connection

### DIFF
--- a/android/app/src/main/kotlin/com/example/yumsg/core/data/ServerConfig.java
+++ b/android/app/src/main/kotlin/com/example/yumsg/core/data/ServerConfig.java
@@ -11,7 +11,13 @@ public class ServerConfig {
         this.organizationName = organizationName;
     }
 
+    public ServerConfig(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
     public String getHost() { return host; }
     public int getPort() { return port; }
     public String getOrganizationName() { return organizationName; }
+    public void setOrganizationName(String organizationName) { this.organizationName = organizationName; }
 }

--- a/android/app/src/main/kotlin/com/example/yumsg/core/network/ServerNetworkManager.java
+++ b/android/app/src/main/kotlin/com/example/yumsg/core/network/ServerNetworkManager.java
@@ -133,14 +133,13 @@ public class ServerNetworkManager implements NetworkManager {
                 // Extract connection parameters
                 String host = (String) connectionParams.get("host");
                 Integer port = (Integer) connectionParams.get("port");
-                String orgName = (String) connectionParams.get("organizationName");
-                
-                if (host == null || port == null || orgName == null) {
+
+                if (host == null || port == null) {
                     throw new IllegalArgumentException("Missing required connection parameters");
                 }
-                
+
                 this.baseUrl = buildBaseUrl(host, port);
-                this.organizationName = orgName;
+                this.organizationName = null;
                 
                 // Initialize HTTP client with SSL pinning
                 initializeHttpClient();
@@ -704,6 +703,8 @@ public class ServerNetworkManager implements NetworkManager {
                     OrgInfoResponse orgData = response.getData();
 
                     // Build organization info
+                    this.organizationName = orgData.organization.name;
+
                     OrganizationInfo orgInfo = new OrganizationInfo(
                         orgData.organization.name,
                         orgData.organization.id

--- a/android/app/src/main/kotlin/com/example/yumsg/core/storage/SharedPreferencesManager.java
+++ b/android/app/src/main/kotlin/com/example/yumsg/core/storage/SharedPreferencesManager.java
@@ -361,22 +361,26 @@ public class SharedPreferencesManager {
             return;
         }
         
-        if (organizationName == null || organizationName.trim().isEmpty()) {
-            Log.w(TAG, "Invalid organization name provided for server config");
-            return;
-        }
-        
+        // Organization name may be null during initial connection
+
         lock.writeLock().lock();
         try {
-            ServerConfig config = new ServerConfig(host.trim(), port, organizationName.trim());
+            ServerConfig config = new ServerConfig(host.trim(), port, organizationName != null ? organizationName.trim() : null);
             String json = gson.toJson(config);
             editor.putString(KEY_SERVER_CONFIG, json).apply();
-            Log.d(TAG, "Server config saved: " + host + ":" + port + " (" + organizationName + ")");
+            Log.d(TAG, "Server config saved: " + host + ":" + port + (organizationName != null ? " (" + organizationName + ")" : ""));
         } catch (Exception e) {
             Log.e(TAG, "Failed to save server config", e);
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    /**
+     * Set server configuration without organization name
+     */
+    public void setServerConfig(String host, int port) {
+        setServerConfig(host, port, null);
     }
     
     /**

--- a/android/app/src/main/kotlin/com/example/yumsg/core/ui/UIBridge.java
+++ b/android/app/src/main/kotlin/com/example/yumsg/core/ui/UIBridge.java
@@ -507,14 +507,13 @@ public class UIBridge implements MethodChannel.MethodCallHandler, EventChannel.S
     private void handleConnectToServer(MethodCall call, MethodChannel.Result result) {
         String host = call.argument("host");
         Integer port = call.argument("port");
-        String organizationName = call.argument("organizationName");
-        
-        if (host == null || port == null || organizationName == null) {
-            result.error("INVALID_ARGUMENTS", "Host, port, and organizationName are required", null);
+
+        if (host == null || port == null) {
+            result.error("INVALID_ARGUMENTS", "Host and port are required", null);
             return;
         }
-        
-        backgroundService.connectToServer(host, port, organizationName)
+
+        backgroundService.connectToServer(host, port)
             .thenAccept(connectionResult -> {
                 mainHandler.post(() -> {
                     Map<String, Object> response = new HashMap<>();

--- a/lib/services/ui_bridge.dart
+++ b/lib/services/ui_bridge.dart
@@ -167,13 +167,11 @@ class UIBridge {
   Future<UIResponse> connectToServer({
     required String host,
     required int port,
-    required String organizationName,
   }) async {
     try {
       final result = await _methodChannelInstance.invokeMethod('connectToServer', {
         'host': host,
         'port': port,
-        'organizationName': organizationName,
       });
       return UIResponse.fromMap(Map<String, dynamic>.from(result));
     } catch (e) {


### PR DESCRIPTION
## Summary
- obtain organization name from server instead of requesting it from the client
- allow SharedPreferencesManager to store server config without organization name
- update server connection workflow and store organization name after fetching organization info
- adjust JNI bridge and Dart bridge for new API

## Testing
- `gradle -p android build` *(fails: local.properties missing)*

------
https://chatgpt.com/codex/tasks/task_e_68613254766083238a3085df75d36ba7