### PR TITLE
Integrate native bridge into auth and connection screens

### DIFF
--- a/lib/models/organization_models.dart
+++ b/lib/models/organization_models.dart
@@ -1,0 +1,45 @@
+class AlgorithmInfo {
+  final String kemAlgorithm;
+  final String symmetricAlgorithm;
+  final String signatureAlgorithm;
+
+  AlgorithmInfo({
+    required this.kemAlgorithm,
+    required this.symmetricAlgorithm,
+    required this.signatureAlgorithm,
+  });
+
+  factory AlgorithmInfo.fromMap(Map<String, dynamic> map) {
+    return AlgorithmInfo(
+      kemAlgorithm: map['kemAlgorithm'] ?? '',
+      symmetricAlgorithm: map['symmetricAlgorithm'] ?? '',
+      signatureAlgorithm: map['signatureAlgorithm'] ?? '',
+    );
+  }
+}
+
+class OrganizationInfo {
+  final String name;
+  final String? id;
+  final String? serverVersion;
+  final AlgorithmInfo? supportedAlgorithms;
+
+  OrganizationInfo({
+    required this.name,
+    this.id,
+    this.serverVersion,
+    this.supportedAlgorithms,
+  });
+
+  factory OrganizationInfo.fromMap(Map<String, dynamic> map) {
+    return OrganizationInfo(
+      name: map['name'] ?? '',
+      id: map['id'],
+      serverVersion: map['serverVersion'],
+      supportedAlgorithms: map['supportedAlgorithms'] != null
+          ? AlgorithmInfo.fromMap(
+              Map<String, dynamic>.from(map['supportedAlgorithms']))
+          : null,
+    );
+  }
+}

--- a/lib/services/ui_bridge.dart
+++ b/lib/services/ui_bridge.dart
@@ -214,7 +214,7 @@ class UIBridge {
       return UIResponse.error('Failed to register user: $e');
     }
   }
-  
+
   /// Set local user (for LOCAL mode)
   Future<UIResponse> setLocalUser({required String username}) async {
     try {
@@ -226,7 +226,7 @@ class UIBridge {
       return UIResponse.error('Failed to set local user: $e');
     }
   }
-  
+
   /// Logout user
   Future<UIResponse> logout() async {
     try {
@@ -236,7 +236,33 @@ class UIBridge {
       return UIResponse.error('Failed to logout: $e');
     }
   }
-  
+
+  /// Get organization information from server
+  Future<Map<String, dynamic>?> getOrganizationInfo() async {
+    try {
+      final result =
+          await _methodChannelInstance.invokeMethod('getOrganizationInfo');
+      final response = UIResponse.fromMap(Map<String, dynamic>.from(result));
+      return response.success ? response.data['organization'] : null;
+    } catch (e) {
+      print('Failed to get organization info: $e');
+      return null;
+    }
+  }
+
+  /// Get supported algorithms from server
+  Future<Map<String, dynamic>?> getServerAlgorithms() async {
+    try {
+      final result =
+          await _methodChannelInstance.invokeMethod('getServerAlgorithms');
+      final response = UIResponse.fromMap(Map<String, dynamic>.from(result));
+      return response.success ? response.data['algorithms'] : null;
+    } catch (e) {
+      print('Failed to get server algorithms: $e');
+      return null;
+    }
+  }
+
   // ===========================
   // CHAT OPERATIONS
   // ===========================


### PR DESCRIPTION
## Summary
- add models for organization and algorithm info
- expose native calls for server info via `UIBridge`
- connect to native layer on server connection screen
- fetch organization info and authenticate/register users using native code

## Testing
- `flutter` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_68613645c2e88323b4ea9b93412e733d