### PR TITLE
Integrate organization key generation

### DIFF
--- a/android/app/src/main/kotlin/com/example/yumsg/core/ui/UIBridge.java
+++ b/android/app/src/main/kotlin/com/example/yumsg/core/ui/UIBridge.java
@@ -102,6 +102,7 @@ public class UIBridge implements MethodChannel.MethodCallHandler, EventChannel.S
     // Method names - Organization
     private static final String METHOD_GET_ORGANIZATION_INFO = "getOrganizationInfo";
     private static final String METHOD_GET_SERVER_ALGORITHMS = "getServerAlgorithms";
+    private static final String METHOD_GENERATE_ORGANIZATION_KEYS = "generateOrganizationKeys";
     
     // Method names - Session Management
     private static final String METHOD_GET_SESSION_INFO = "getSessionInfo";
@@ -408,6 +409,9 @@ public class UIBridge implements MethodChannel.MethodCallHandler, EventChannel.S
                     break;
                 case METHOD_GET_SERVER_ALGORITHMS:
                     handleGetServerAlgorithms(call, result);
+                    break;
+                case METHOD_GENERATE_ORGANIZATION_KEYS:
+                    handleGenerateOrganizationKeys(call, result);
                     break;
                     
                 // Session Management
@@ -1285,7 +1289,7 @@ public class UIBridge implements MethodChannel.MethodCallHandler, EventChannel.S
                     algMap.put("kemAlgorithm", algorithms.getKemAlgorithm());
                     algMap.put("symmetricAlgorithm", algorithms.getSymmetricAlgorithm());
                     algMap.put("signatureAlgorithm", algorithms.getSignatureAlgorithm());
-                    
+
                     Map<String, Object> response = createSuccessResponse("Server algorithms retrieved");
                     response.put("algorithms", algMap);
                     result.success(response);
@@ -1293,6 +1297,23 @@ public class UIBridge implements MethodChannel.MethodCallHandler, EventChannel.S
             })
             .exceptionally(throwable -> {
                 mainHandler.post(() -> result.error("ALGORITHM_ERROR", throwable.getMessage(), null));
+                return null;
+            });
+    }
+
+    private void handleGenerateOrganizationKeys(MethodCall call, MethodChannel.Result result) {
+        backgroundService.generateOrganizationKeys()
+            .thenAccept(success -> {
+                mainHandler.post(() -> {
+                    if (success) {
+                        result.success(createSuccessResponse("Organization keys generated"));
+                    } else {
+                        result.error("ORG_KEY_ERROR", "Failed to generate organization keys", null);
+                    }
+                });
+            })
+            .exceptionally(throwable -> {
+                mainHandler.post(() -> result.error("ORG_KEY_ERROR", throwable.getMessage(), null));
                 return null;
             });
     }

--- a/lib/models/chat_models.dart
+++ b/lib/models/chat_models.dart
@@ -48,7 +48,7 @@ class FileAttachment {
 }
 
 class ChatInfo {
-  final int id;
+  final String id;
   final String name;
   final String lastMessage;
   final String time;
@@ -60,11 +60,34 @@ class ChatInfo {
   ChatInfo({
     required this.id,
     required this.name,
-    required this.lastMessage,
-    required this.time,
-    required this.unread,
+    this.lastMessage = '',
+    this.time = '',
+    this.unread = 0,
     required this.avatar,
-    required this.isOnline,
+    this.isOnline = false,
     this.isGroup = false,
   });
+
+  factory ChatInfo.fromMap(Map<String, dynamic> map) {
+    final name = map['name'] ?? 'Chat';
+    final avatar = name.isNotEmpty ? name[0].toUpperCase() : '?';
+    String time = '';
+    if (map['lastActivity'] != null) {
+      final dt = DateTime.fromMillisecondsSinceEpoch(map['lastActivity']);
+      final h = dt.hour.toString().padLeft(2, '0');
+      final m = dt.minute.toString().padLeft(2, '0');
+      time = '$h:$m';
+    }
+
+    return ChatInfo(
+      id: map['id'] ?? '',
+      name: name,
+      lastMessage: map['lastMessage'] ?? '',
+      time: time,
+      unread: map['unread'] ?? 0,
+      avatar: avatar,
+      isOnline: map['isOnline'] ?? false,
+      isGroup: map['isGroup'] ?? false,
+    );
+  }
 }

--- a/lib/services/ui_bridge.dart
+++ b/lib/services/ui_bridge.dart
@@ -263,6 +263,17 @@ class UIBridge {
     }
   }
 
+  /// Generate and save organization signature keys
+  Future<UIResponse> generateOrganizationKeys() async {
+    try {
+      final result =
+          await _methodChannelInstance.invokeMethod('generateOrganizationKeys');
+      return UIResponse.fromMap(Map<String, dynamic>.from(result));
+    } catch (e) {
+      return UIResponse.error('Failed to generate organization keys: $e');
+    }
+  }
+
   // ===========================
   // CHAT OPERATIONS
   // ===========================


### PR DESCRIPTION
## Summary
- create platform method to generate & save organization signature keys
- expose `generateOrganizationKeys` on UIBridge
- trigger key generation when chat list opens in server mode
- load chat list from native DB and update when ChatEstablished event is emitted

## Testing
- `dart format lib/models/chat_models.dart lib/screens/chat_list_screen.dart lib/services/ui_bridge.dart` *(failed: dart not found)*
- `./gradlew test` *(failed: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68613ae8c470832390aca94e45ef9688